### PR TITLE
Add administrative sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Now, let's see the simplest way we can implement this variant. We can assume tha
 Go to `frontend/frontend.py` and comment Line 17 and uncomment Lines 19 - 29 (You will find a comment telling you what to do). These lines add information to the response cookie about the current variant to serve. We assign this variant randomly. How you assign the variant depends on your experiment setup.
 We can use information later from this cookie to know which variant to serve.  
 
-Rebuild your containers use `docker compose up --build -d`. Now, repeat the above steps of running your application, clearing the cookies, and refreshing a couple of times: you should see a different variant in some of these times where some of these variants would end up with the "-- NEW VARIANT" message. If you can't see it, try decreasing the expiry time of the cookie to 20seconds and refresh every 20 seconds. You should see different variants being served.
+Rebuild your containers use `docker compose up --build -d`. Now, repeat the above steps of running your application, clearing the cookies, and refreshing a couple of times: you should see a different variant in some of these times where some of these variants would end up with the "-- NEW VARIANT" message. If you can't see it, try decreasing the expiry time of the cookie to 20 seconds and refresh every 20 seconds. You should see different variants being served.
 
 ### Step 2: Log the experiment results
 
@@ -75,6 +75,7 @@ show collections # this will display all collections
 db.students.find() # will display all students
 db.ab_test_logs.find() # will display all abtesting results
 ```
+If you cannot see the `abdemo` database, you may need to run `docker exec -it demo-ab-mongo mongosh` to check from inside the Docker container. If you are using Docker Desktop, you can click on the `demo-ab-mongo` container and go to the `exec` tab.
 
 Let's get some insights on the average number of clicks for users from each variant:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# Overview
+# A/B Testing
 
-This repo provides two simple ways to implement AB testing. Note that this repo does not have authentication and thus we don't have user identities to attach a variant to or to track. In your project, you have user identities and accordingly, you can save the assigned variant to a user (or in a separate experiment collection) such that you can analyze metrics at a user level later after your experiment.
+## Overview
+
+This repo provides two simple ways to implement A/B testing. Note that this repo does not have authentication and thus we don't have user identities to attach a variant to or to track. In your project, you have user identities and accordingly, you can save the assigned variant to a user (or in a separate experiment collection) such that you can analyze metrics at a user level later after your experiment.
+
+### Learning Objectives
+- Implement A/B testing for a Flask application
+- Assign users into groups via cookies
+- Collect and analyze test data
+
+### Prior Knowledge
+- Testing in production (Chaos Engineering, A/B testing)
+- Usage of Docker & MongoDB
+
+### Time Estimate: 20 minutes
 
 
 ## How to run the application
@@ -102,7 +115,7 @@ You should get something similar to this:
 Run the experiment as above, making sure to generate enough data. Run the queries in mongosh and take a screenshot of your results showing average clicks per user between the variants.
 
 
-## Using decorators to streamline your AB testing
+## Using decorators to streamline your A/B testing
 
 You can define custom decorators to help you manage your A/B testing. This allows you to leverage common code to create many A/B experiments without having to modify the code too much every time.
 


### PR DESCRIPTION
Once again there was an existing description that I left in. I included Docker and MongoDB in the prior knowledge this time since they are more heavily involved than usual for this exercise.

One unrelated comment I have is that I wasted a bit of time thinking I had an issue with either Docker or MongoDB, since the new database wasn't showing up when I used `mongosh`. I eventually checked from inside the relevant container using Docker Desktop, but that was not made clear in step 3.